### PR TITLE
Add user capability check

### DIFF
--- a/src/Insights.php
+++ b/src/Insights.php
@@ -785,6 +785,10 @@ class Insights {
             wp_send_json_error( 'Nonce verification failed' );
         }
 
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'You are not allowed for this task' );
+        }
+
         $data                = $this->get_tracking_data();
         $data['reason_id']   = sanitize_text_field( $_POST['reason_id'] );
         $data['reason_info'] = isset( $_REQUEST['reason_info'] ) ? trim( stripslashes( $_REQUEST['reason_info'] ) ) : '';


### PR DESCRIPTION
This is Rafiqul from Directorist team, we are really proud of using your amazing solution.

Recently we received a security report saying '**WordPress Directorist Plugin <= 7.4.5 is vulnerable to Broken Access Control**' which is not correct. But I have found the capability check is missing when submitting data to remote API.

### Issue details:
URL: https://patchstack.com/database/report-preview/6360f917-a21a-4e1f-88d3-4791ff04bc0f
PIN: HtpAUaZhYHGu4n4w