### PR TITLE
update: Added client parameter to appsero_custom_deactivation_reasons hooks

### DIFF
--- a/src/Insights.php
+++ b/src/Insights.php
@@ -844,7 +844,7 @@ class Insights {
 
         $this->deactivation_modal_styles();
         $reasons        = $this->get_uninstall_reasons();
-        $custom_reasons = apply_filters( 'appsero_custom_deactivation_reasons', [] );
+        $custom_reasons = apply_filters( 'appsero_custom_deactivation_reasons', [], $this->client );
         ?>
 
         <div class="wd-dr-modal" id="<?php echo $this->client->slug; ?>-wd-dr-modal">


### PR DESCRIPTION
Previously there is no way to check if custom deactivation reasons were added for a specific plugin. This added hook parameter will solve the issue.
Closes #26