### PR TITLE
fix: Broken Access Control Vulnerability Issue

### DIFF
--- a/src/Insights.php
+++ b/src/Insights.php
@@ -496,6 +496,10 @@ class Insights
             return;
         }
 
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
         if (isset($_GET[$this->client->slug . '_tracker_optin']) && $_GET[$this->client->slug . '_tracker_optin'] === 'true') {
             $this->optin();
 


### PR DESCRIPTION
Fixed a broken access control vulnerability that allowed lower privileged users to execute plugin settings without permission. Added current_user_can() checks to prevent unauthorized access.