### PR TITLE
fix: prevent fatal error if used with old version of Appsero Client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -139,7 +139,7 @@ class Client {
         }
 
         // show deprecated notice
-        _deprecated_function( __CLASS__ . '::updater', '2.0', '\Appsero\Updater::init, for more details please visit: https://app.getwemail.io/campaigns/94eef570-bc95-448f-9178-1386f009b2d9' );
+        _deprecated_function( __CLASS__ . '::updater', '2.0', '\Appsero\Updater::init($client);, for more details please visit: https://github.com/Appsero/updater' );
 
         // initialize the new updater
         if ( method_exists( '\Appsero\Updater', 'init' ) ) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -128,6 +128,26 @@ class Client {
     }
 
     /**
+     * Initialize plugin/theme updater
+     *
+     * @return void
+     */
+    public function updater() {
+        // do not show update notice on ajax request and rest api request
+        if ( wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+            return;
+        }
+
+        // show deprecated notice
+        _deprecated_function( __CLASS__ . '::updater', '2.0', '\Appsero\Updater::init, for more details please visit: https://app.getwemail.io/campaigns/94eef570-bc95-448f-9178-1386f009b2d9' );
+
+        // initialize the new updater
+        if ( method_exists( '\Appsero\Updater', 'init' ) ) {
+            \Appsero\Updater::init( $this );
+        }
+    }
+
+    /**
      * Initialize license checker
      *
      * @return Appsero\License

--- a/src/Client.php
+++ b/src/Client.php
@@ -139,7 +139,7 @@ class Client {
         }
 
         // show deprecated notice
-        _deprecated_function( __CLASS__ . '::updater', '2.0', '\Appsero\Updater::init($client);, for more details please visit: https://github.com/Appsero/updater' );
+        _deprecated_function( __CLASS__ . '::updater', '2.0', '\Appsero\Updater::init($client);, for more details please visit: https://appsero.com/docs/appsero-developers-guide/appsero-client/appsero-sdk-updater-changes/' );
 
         // initialize the new updater
         if ( method_exists( '\Appsero\Updater', 'init' ) ) {


### PR DESCRIPTION
We are getting multiple fatal error reports after updating the Appsero/Client library. The use cases are virtually infinite. Let me explain a bit further.
1. Some users are using the latest version of the Dokan Lite plugin and an old version of the Dokan Pro plugin. From the old version of Dokan Pro, Appsero\Client::updater() has been called and the user is getting a fatal error.  In that case, there is no way the user will be able to update Dokan Pro since their site is inaccessible. Kindly check the error details here: https://github.com/getdokan/dokan/issues/2160 


2. Site user updated Dokan or any other plugin with the latest version of Appsero/Client. Some plugins still use the old version configured. From there plugin Appsero\Client::updater() was called. The user is getting a fatal error.
Below is an example:
```
2024-01-29T07:09:38+00:00 CRITICAL Uncaught Error: Call to undefined method Appsero\Client::updater() in /home/n8zviv35kkwy/public_html/wp-content/plugins/wp-mobile-bottom-menu-pro/wp-bnav-pro.php:66
Stack trace:
#0 /home/n8zviv35kkwy/public_html/wp-content/plugins/wp-mobile-bottom-menu-pro/wp-bnav-pro.php(84): appsero_init_tracker_wp_bnav_pro()
#1 /home/n8zviv35kkwy/public_html/wp-settings.php(473): include_once('/home/n8zviv35k...')
#2 /home/n8zviv35kkwy/public_html/wp-config.php(103): require_once('/home/n8zviv35k...')
#3 /home/n8zviv35kkwy/public_html/wp-load.php(50): require_once('/home/n8zviv35k...')
#4 /home/n8zviv35kkwy/public_html/wp-admin/admin-ajax.php(22): require_once('/home/n8zviv35k...')
#5 {main}
  thrown in /home/n8zviv35kkwy/public_html/wp-content/plugins/wp-mobile-bottom-menu-pro/wp-bnav-pro.php on line 66
```



## Proposed Solution

The proposed solution will prevent the fatal error as well as display a deprecated warning to update the Appsero client library. Also, the proposed solution includes the new Updater Method ie: `\Appsero\Updater::init( $this )` being called from the deprecated `Client::updater()` method.

```
PHP Deprecated:  Function Appsero\Client::updater is deprecated since version 2.0! Use \Appsero\Updater::init, for more details please visit: https://github.com/Appsero/updater instead. in /Users/wedevs/htdocs/dokan/wp-includes/functions.php on line 6031
```

